### PR TITLE
Fixed Adding Playlists to Spotify Account

### DIFF
--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -44,7 +44,7 @@ const Spotify = {
  			}
 		},
 
-		savePlaylist(name, trackURIs) {
+		async savePlaylist(name, trackURIs) {
 			if(accessToken === undefined) {
 				this.getAccessToken();
 			}
@@ -52,8 +52,8 @@ const Spotify = {
 				return;
 			} else {
 				let userAccessToken = this.getAccessToken();
-				let headers = {Authorization: userAccessToken};
-				let userId = this.findUserId(headers);
+				let headers = {Authorization: `Bearer ${userAccessToken}`};
+				let userId = await this.findUserId();
 				let playlistID;
 				fetch(`https://api.spotify.com/v1/users/${userId}/playlists`, {
 					method: 'POST',
@@ -71,17 +71,19 @@ const Spotify = {
 			}
 		},
 
-		findUserId(headers) {
+		findUserId() {
 			if(accessToken === undefined) {
 				this.getAccessToken();
 			}
-			let id;
-			fetch(`https://api.spotify.com/v1/me`, {headers: headers}
+			let userId;
+			return fetch(`https://api.spotify.com/v1/me`, {headers: {
+				Authorization: `Bearer ${accessToken}`
+			}}
 				).then(response => {return response.json()}
 				).then(jsonResponse => {
-					id = jsonResponse[0].id;
+					userId = jsonResponse.id;
+					return userId;
 				});
-				return id;
 		}
 	};
 

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -70,14 +70,14 @@ const Spotify = {
 
 		addTracks(playlistID, trackURIs, userId) {
 			console.log(trackURIs);
-			fetch(`https://api.spotify.com/v1/users/${userId}/playlists/${playlistID}/tracks`), {
+			fetch(`https://api.spotify.com/v1/users/${userId}/playlists/${playlistID}/tracks`, {
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${accessToken}`,
 					"Content-Type": 'application/json'
 				},
 				body: JSON.stringify({uris: trackURIs})
-			}
+			});
 		},
 
 		findUserId() {

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -48,7 +48,7 @@ const Spotify = {
 			if(accessToken === undefined) {
 				this.getAccessToken();
 			}
-			if (name === undefined || trackURIs === undefined) {
+			if (name === 'New Playlist' || name === undefined || trackURIs === undefined) {
 				return;
 			} else {
 				let userAccessToken = this.getAccessToken();

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -48,11 +48,9 @@ const Spotify = {
 			if(accessToken === undefined) {
 				this.getAccessToken();
 			}
-			if (name === 'New Playlist' || name === undefined || trackURIs === undefined) {
+			if (name === undefined || trackURIs === undefined) {
 				return;
 			} else {
-				let userAccessToken = this.getAccessToken();
-				let headers = {Authorization: `Bearer ${userAccessToken}`};
 				let userId = await this.findUserId();
 				let playlistID;
 				fetch(`https://api.spotify.com/v1/users/${userId}/playlists`, {
@@ -61,13 +59,24 @@ const Spotify = {
 						Authorization: `Bearer ${accessToken}`,
 						"Content-Type": 'application/json'
 					},
-					body: {
-						name: name
-					}
+					body: JSON.stringify({name: name})
 				}).then(response => {return response.json()}
 				).then(playlist => {
 					playlistID = playlist.id;
+					this.addTracks(playlistID, trackURIs, userId);
 				});
+			}
+		},
+
+		addTracks(playlistID, trackURIs, userId) {
+			console.log(trackURIs);
+			fetch(`https://api.spotify.com/v1/users/${userId}/playlists/${playlistID}/tracks`), {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+					"Content-Type": 'application/json'
+				},
+				body: JSON.stringify({uris: trackURIs})
 			}
 		},
 


### PR DESCRIPTION
As mentioned in Issue #1, you could not save the playlist to your account, caused by bugs with the coding. All bugs should now be straightened out, so you can successfully create and save playlists to your Spotify account.