### PR TITLE
Fixed Track Removal

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -49,7 +49,8 @@ class App extends React.Component {
 			}
 		}
 		if (trackIndex !== -1) {
-			const newPlaylist = this.state.playlistTracks.splice(trackIndex, 1);
+			const newPlaylist = this.state.playlistTracks;
+			newPlaylist.splice(trackIndex, 1);
 			this.setState({playlistTracks: newPlaylist});
 		}
 	}


### PR DESCRIPTION
Had an issue where attempting to remove a track from the playlist removed every track besides the one that you were attempting to remove. This is fixed by just calling the .splice method, instead of passing what is returned to the state of it, since it returns what is removed from the array. This fixes issue #4