### PR TITLE
Added previews to the Track Objects

### DIFF
--- a/src/Components/Track/Track.css
+++ b/src/Components/Track/Track.css
@@ -32,3 +32,15 @@
   font-weight: 300;
   color: rgba(256, 256, 256, 0.8);
 }
+
+.Track-information a {
+  font-size: .5rem;
+  font-weight: 50;
+  margin-top: 7px;
+  cursor: pointer;
+  transition: color .25s;
+}
+
+.Track-information a:hover {
+  color: rgba(265, 265, 265, .5);
+}

--- a/src/Components/Track/Track.js
+++ b/src/Components/Track/Track.js
@@ -8,6 +8,7 @@ export class Track extends React.Component {
 		this.addTrack = this.addTrack.bind(this);
 		this.removeTrack = this.removeTrack.bind(this);
 		this.renderAction = this.renderAction.bind(this);
+		this.playPreview = this.playPreview.bind(this);
 	}
 
 	addTrack() {
@@ -26,12 +27,17 @@ export class Track extends React.Component {
 		}
 	}
 
+	playPreview() {
+		window.open(this.props.preview);
+	}
+
 	render() {
 		return(
 			<div className="Track">
   				<div className="Track-information">
     				<h3>{this.props.name}</h3>
     				<p>{this.props.artist} | {this.props.album}</p>
+    				<a onClick={this.playPreview}>preview</a>
   				</div>
   				<a className="Track-action" onClick={this.renderAction}>+</a>
 			</div>

--- a/src/Components/TrackList/TrackList.js
+++ b/src/Components/TrackList/TrackList.js
@@ -14,6 +14,7 @@ export class TrackList extends React.Component {
     				name={track.name}
     				artist={track.artist}
     				album={track.album}
+                    preview={track.preview}
     				onAdd={this.props.onAdd}
                     onRemove={this.props.onRemove}
                     isRemoval={this.props.isRemoval}

--- a/src/util/Spotify.js
+++ b/src/util/Spotify.js
@@ -35,7 +35,8 @@ const Spotify = {
      				name: track.name,
      				artist: track.artists[0].name,
      				album: track.album.name,
-     				uri: track.uri
+     				uri: track.uri,
+     				preview: track.preview_url
      			}));
      			return tracks;
    			}


### PR DESCRIPTION
Added the ability to allow a user to click on the 'preview' link for a track, and have it open a webpage where a 30 second preview of the track can be played, also touched on the CSS to make the preview anchor link not look massive and awkward. This takes care of issue #13, so that can be closed as well